### PR TITLE
Fixes export bug when using ng-table-to-csv on ngTable

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name"           : "ng-table-to-csv",
   "description"    : "Export data from ngTable to CSV (Forked from ng-table-export)",
-  "version"        : "0.3.1",
+  "version"        : "0.3.2",
   "authors"        : [
     {
       "name" : "Vitalii Savchuk",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name"           : "ng-table-to-csv",
   "description"    : "Export data from ngTable to CSV (Forked from ng-table-export)",
-  "version"        : "0.3.2",
+  "version"        : "0.3.1",
   "authors"        : [
     {
       "name" : "Vitalii Savchuk",

--- a/src/ng-table-to-csv/directives/ngTableToCsv.exportCsv.js
+++ b/src/ng-table-to-csv/directives/ngTableToCsv.exportCsv.js
@@ -32,12 +32,12 @@
                     tds = tr.find('td');
                   }
                   angular.forEach(tds, function (td, i) {
-                    var value = '';
+                    var value;
                     td = angular.element(td);
                     if (!td.hasClass(ignoreSelector)) {
                       value = angular.element(td).text();
+                      rowData += csv.stringify(value) + separator;
                     }
-                    rowData += csv.stringify(value) + separator;
                   });
                   rowData = rowData.slice(0, rowData.length - 1); //remove last separator
                   data += rowData + '\n';


### PR DESCRIPTION
This release fixes an empty-cell/column bug experienced for people using ngTable tables with ng-table-to-csv. Currently, when using export-ignore on a cell or header, the empty cell is still exported instead of being omitted as a user would expect.